### PR TITLE
[#12] SP 이벤트 브리지 - ThreatComponent 일부 패치코드 적용 못함. - 사유 내용 확인

### DIFF
--- a/Source/JRPG/Private/Combat/Battle/BasicCombatSubsystem.cpp
+++ b/Source/JRPG/Private/Combat/Battle/BasicCombatSubsystem.cpp
@@ -7,6 +7,7 @@
 #include "Combat/Stats/HPComponent.h"
 #include "Combat/Stats/APComponent.h"
 #include "Combat/SP/SPComponent.h"
+#include "Combat/SP/SynergyPointSubsystem.h"
 
 #include "Combat/Threat/ThreatComponent.h"
 #include "Combat/Groggy/GroggyComponent.h"
@@ -64,26 +65,39 @@ FCombatActionResult UBasicCombatSubsystem::ExecuteBasicAttack(const FBasicAttack
 	Out.Attacker = Attacker;
 	Out.Target = Target;
 	Out.Breakdown = UCombatFormulaLibrary::BuildDamage(
-	Atk,
-	Def,
-	Req.BasePower,
-	Req.AttackScale,
-	Req.DefenseScale,
-	Req.PowerMultiplier,
-	Req.bAllowCrit,
-	CritRate,
-	CritBonus,
-	Req.VarianceMin,
-	Req.VarianceMax,
-	Req.GroggyPower,
-	Req.ThreatMultiplier
+		Atk,
+		Def,
+		Req.BasePower,
+		Req.AttackScale,
+		Req.DefenseScale,
+		Req.PowerMultiplier,
+		Req.bAllowCrit,
+		CritRate,
+		CritBonus,
+		Req.VarianceMin,
+		Req.VarianceMax,
+		Req.GroggyPower,
+		Req.ThreatMultiplier
 		);
 
 	TargetHP->ApplyDamage(Out.Breakdown.FinalDamage, Attacker, Req.ReasonTag);
-
+	
 	if (TargetGroggy && Out.Breakdown.GroggyDamage > 0.f)
 	{
 		TargetGroggy->AddGroggyDamage(Out.Breakdown.GroggyDamage, Attacker, Req.ReasonTag);
+	}
+	
+	if (USynergyPointSubsystem* SP = GetWorld() ? GetWorld()->GetSubsystem<USynergyPointSubsystem>() : nullptr)
+	{
+		if (Out.Breakdown.FinalDamage > 0.f)
+		{
+			SP->ReportDamage(Attacker,Target,Out.Breakdown.FinalDamage,false,Req.ReasonTag);
+		}
+
+		if (Out.Breakdown.GroggyDamage > 0.f)
+		{
+			SP->ReportBreak(Attacker, Target, Out.Breakdown.GroggyDamage, false, false, Req.ReasonTag);
+		}
 	}
 
 	if (TargetThreat && Out.Breakdown.ThreatGenerated > 0.f)

--- a/Source/JRPG/Private/Combat/Chain/ChainAttackSubsystem.cpp
+++ b/Source/JRPG/Private/Combat/Chain/ChainAttackSubsystem.cpp
@@ -7,6 +7,7 @@
 #include "Combat/Characters/CombatCharacterDataAsset.h"
 #include "Combat/Characters/CombatCharacterComponent.h"
 
+#include"Combat/SP/SynergyPointSubsystem.h"
 #include "Combat/Stats/HPComponent.h"
 
 UBattleSessionSubsystem* UChainAttackSubsystem::GetBattle() const
@@ -89,6 +90,14 @@ bool UChainAttackSubsystem::TryStartChain(AActor* Starter, const FChainAttackCon
 	if (!Starter) return false;
 	if (!IsPlayerActor(Starter)) return false;
 
+	if (USynergyPointSubsystem* SP =GetWorld() ? GetWorld()->GetSubsystem<USynergyPointSubsystem>() : nullptr)
+	{
+		if (!SP->IsChainReady())
+		{
+			return false;
+		}
+	}
+	
 	UBattleSessionSubsystem* Battle = GetBattle();
 	if (!Battle || !Battle->IsBattleActive()) return false;
 	if (!Battle->CanActorActNow(Starter)) return false;

--- a/Source/JRPG/Private/Combat/Groggy/GroggyComponent.cpp
+++ b/Source/JRPG/Private/Combat/Groggy/GroggyComponent.cpp
@@ -1,4 +1,4 @@
-﻿#include "Combat/Groggy/GroggyComponent.h"
+﻿#include "JRPG/Public/Combat/Groggy/GroggyComponent.h"
 #include "Combat/Characters/Stats/CombatStatsComponent.h"
 
 UGroggyComponent::UGroggyComponent()
@@ -13,13 +13,16 @@ void UGroggyComponent::BeginPlay()
 	Stats = GetOwner() ? GetOwner()->FindComponentByClass<UCombatStatsComponent>() : nullptr;
 }
 
-void UGroggyComponent::AddGroggyDamage(float Amount, AActor*, FName)
+void UGroggyComponent::AddGroggyDamage(float Amount, AActor* SourceActor, FName ReasonTag, bool bFromTacticalReservation = false)
 {
 	if (Amount <= 0.f) 
 		return;
 	
 	if (bGroggy) 
 		return;
+	
+	LastBreakSource = SourceActor;
+	bLastBreakFromTacticalReservation = bFromTacticalReservation;
 
 	Gauge = FMath::Clamp(Gauge + Amount, 0.f, MaxGauge);
 	if (Gauge >= MaxGauge)
@@ -28,7 +31,7 @@ void UGroggyComponent::AddGroggyDamage(float Amount, AActor*, FName)
 	}
 }
 
-void UGroggyComponent::ResetGauge(FName)
+void UGroggyComponent::ResetGauge(FName ReasonTag)
 {
 	Gauge = 0.f;
 	
@@ -51,6 +54,14 @@ void UGroggyComponent::EnterGroggy()
 	}
 
 	OnGroggyStateChanged.Broadcast(true);
+	
+	if (USynergyPointSubsystem* SP = GetWorld() ? GetWorld()->GetSubsystem<USynergyPointSubsystem>() : nullptr)
+	{
+		if (AActor* Source = LastBreakSource.Get())
+		{
+			SP->ReportBreak(Source, GetOwner(), 0.f, true, bLastBreakFromTacticalReservation, "Groggy.StunTrigger");
+		}
+	}
 }
 
 void UGroggyComponent::ExitGroggy()
@@ -66,7 +77,7 @@ void UGroggyComponent::ExitGroggy()
 	OnGroggyStateChanged.Broadcast(false);
 }
 
-void UGroggyComponent::TickComponent(float DeltaTime, ELevelTick, FActorComponentTickFunction*)
+void UGroggyComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	if (!bGroggy)
 		return;

--- a/Source/JRPG/Private/Combat/Items/CombatItemExecutionSubsystem.cpp
+++ b/Source/JRPG/Private/Combat/Items/CombatItemExecutionSubsystem.cpp
@@ -5,11 +5,16 @@
 #include "Combat/Items/CombatUsableItemDataAsset.h"
 
 #include "Combat/Characters/CombatParticipantInterface.h"
+
 #include "Combat/Stats/HPComponent.h"
 #include "Combat/Stats/APComponent.h"
+
 #include "Combat/SP/SPComponent.h"
+#include "Combat/SP/SynergyPointSubsystem.h"
+
 #include "Combat/Groggy/GroggyComponent.h"
 #include "Combat/Threat/ThreatComponent.h"
+
 #include "Combat/Status/StatusEffectComponent.h"
 #include "Combat/Status/CombatStatusCleanseInterface.h"
 
@@ -44,11 +49,14 @@ bool UCombatItemExecutionSubsystem::IsSameTeam(AActor* A, AActor* B) const
 
 bool UCombatItemExecutionSubsystem::IsEnemyTeam(AActor* A, AActor* B) const
 {
-	if (!A || !B) return false;
+	if (!A || !B) 
+		return false;
 
 	ICombatParticipantInterface* PA = Cast<ICombatParticipantInterface>(A);
 	ICombatParticipantInterface* PB = Cast<ICombatParticipantInterface>(B);
-	if (!PA || !PB)returnfalse;
+	
+	if (!PA || !PB) 
+		return false;
 
 	const ECombatTeam TA = PA->GetCombatTeam();
 	const ECombatTeam TB = PB->GetCombatTeam();
@@ -197,15 +205,24 @@ bool UCombatItemExecutionSubsystem::WouldAnyEffectApply(
 FCombatItemUseResult UCombatItemExecutionSubsystem::ExecuteUse(const FCombatItemUseRequest& Request)
 {
 	AActor* User = Request.User.Get();
-	if (!User)return FCombatItemUseResult::Fail("Reject.InvalidUser");
-	if (!IsAliveCombatant(User))return FCombatItemUseResult::Fail("Reject.UserDead");
+	if (!User) 
+		return FCombatItemUseResult::Fail("Reject.InvalidUser");
+	
+	if (!IsAliveCombatant(User))
+		return FCombatItemUseResult::Fail("Reject.UserDead");
 
 	UCombatItemComponent* ItemComp = User->FindComponentByClass<UCombatItemComponent>();
-	if (!ItemComp)return FCombatItemUseResult::Fail("Reject.NoItemComponent");
+	USynergyPointSubsystem* SP = GetWorld() ? GetWorld()->GetSubsystem<USynergyPointSubsystem>() : nullptr;
+	
+	if (!ItemComp) 
+		return FCombatItemUseResult::Fail("Reject.NoItemComponent");
 
 	UCombatUsableItemDataAsset* ItemDef = ItemComp->FindItemDef(Request.ItemId);
-	if (!ItemDef)return FCombatItemUseResult::Fail("Reject.ItemNotFound");
-	if (!ItemComp->HasItem(ItemDef->ItemId, 1))return FCombatItemUseResult::Fail("Reject.OutOfItem");
+	if (!ItemDef)
+		return FCombatItemUseResult::Fail("Reject.ItemNotFound");
+	
+	if (!ItemComp->HasItem(ItemDef->ItemId, 1))
+		return FCombatItemUseResult::Fail("Reject.OutOfItem");
 
 	TArray<AActor*> Targets;
 	for (const TWeakObjectPtr<AActor>& W : Request.Targets)
@@ -252,18 +269,29 @@ FCombatItemUseResult UCombatItemExecutionSubsystem::ExecuteUse(const FCombatItem
 		UThreatComponent* Threat = T->FindComponentByClass<UThreatComponent>();
 		UStatusEffectComponent* Status = T->FindComponentByClass<UStatusEffectComponent>();
 
-		if (HP && ItemDef->HealHP > 0.f)
+		if (HP&&ItemDef->HealHP > 0.f)
 		{
 			const float Before = HP->GetHP();
+			const float BeforeRatio = HP->GetMaxHP() > 0.f ? (Before / HP->GetMaxHP()) : 1.f;
+
 			HP->Heal(ItemDef->HealHP, User, ItemDef->ItemId);
-			const float After = HP->GetHP();
-			Out.Breakdown.TotalHealedHP += FMath::Max(0.f, After - Before);
+
+			const float After = HP-> GetHP();
+			const float Delta = FMath::Max(0.f,After-Before);
+
+			Out.Breakdown.TotalHealedHP += Delta;
+
+			if (SP && Delta > 0.f)
+			{
+				SP->ReportHeal(User,T,Delta,BeforeRatio,false,ItemDef->ItemId);
+			}
 		}
 
 		if (AP && ItemDef->RestoreAP > 0)
 		{
 			const int32 Before = AP->GetAP();
 			AP->Restore(ItemDef->RestoreAP, ItemDef->ItemId);
+			
 			const int32 After = AP->GetAP();
 			Out.Breakdown.TotalRestoredAP += FMath::Max(0, After - Before);
 		}
@@ -272,22 +300,35 @@ FCombatItemUseResult UCombatItemExecutionSubsystem::ExecuteUse(const FCombatItem
 		{
 			const int32 Before = SP->GetSP();
 			SP->AddSP(ItemDef->GrantSP, ItemDef->ItemId);
+			
 			const int32 After = SP->GetSP();
 			Out.Breakdown.TotalGrantedSP += FMath::Max(0, After - Before);
 		}
 
-		if (HP && ItemDef->FlatDamage > 0.f)
+		if (HP&&ItemDef->FlatDamage>0.f)
 		{
 			const float Before = HP->GetHP();
 			HP->ApplyDamage(ItemDef->FlatDamage, User, ItemDef->ItemId);
 			const float After = HP->GetHP();
-			Out.Breakdown.TotalDealtDamage += FMath::Max(0.f, Before - After);
+			const float Delta = FMath::Max(0.f, Before - After);
+
+			Out.Breakdown.TotalDealtDamage+=Delta;
+
+			if (SP && Delta > 0.f)
+			{
+				SP->ReportDamage(User, T, Delta, false, ItemDef->ItemId);
+			}
 		}
 
 		if (Groggy && ItemDef->FlatGroggyDamage > 0.f)
 		{
 			Groggy->AddGroggyDamage(ItemDef->FlatGroggyDamage, User, ItemDef->ItemId);
 			Out.Breakdown.TotalGroggyDamage += ItemDef->FlatGroggyDamage;
+
+			if (SP)
+			{
+				SP->ReportBreak(User, T, ItemDef->FlatGroggyDamage, false, false, ItemDef->ItemId);
+			}
 		}
 
 		if (Threat && !FMath::IsNearlyZero(ItemDef->FlatThreatToUserOnTarget))
@@ -298,10 +339,31 @@ FCombatItemUseResult UCombatItemExecutionSubsystem::ExecuteUse(const FCombatItem
 
 		if (Status && ItemDef->ApplyStatus)
 		{
-			if (FMath::FRand() <= FMath::Clamp(ItemDef->StatusChance, 0.f, 1.f))
+			if (FMath::FRand() <= FMath::Clamp(ItemDef->StatusChance,0.f,1.f))
 			{
 				Status->ApplyStatus(ItemDef->ApplyStatus, User, ItemDef->StatusStacks, ItemDef->ItemId);
 				Out.Breakdown.StatusAppliedCount += 1;
+
+				if (SP)
+				{
+					ICombatParticipantInterface* PU = Cast<ICombatParticipantInterface>(User);
+					ICombatParticipantInterface* PT = Cast<ICombatParticipantInterface>(T);
+
+					const bool bEnemy =
+						PU && PT &&
+						PU->GetCombatTeam() != ECombatTeam::Neutral &&
+						PT->GetCombatTeam() != ECombatTeam::Neutral &&
+						PU->GetCombatTeam() != PT->GetCombatTeam();
+
+					if (bEnemy)
+					{
+						SP->ReportDebuff(User, T, ItemDef->ApplyStatus->StatusId, false, ItemDef->ItemId);
+					}
+					else
+					{
+						SP->ReportBuff(User, T, ItemDef->ApplyStatus->StatusId, false, ItemDef->ItemId);
+					}
+				}
 			}
 		}
 
@@ -316,6 +378,21 @@ FCombatItemUseResult UCombatItemExecutionSubsystem::ExecuteUse(const FCombatItem
 					ItemDef->ItemId);
 
 				Out.Breakdown.StatusRemovedCount += Removed;
+
+				if (SP && Removed > 0)
+				{
+					bool bCriticalCC = false;
+					for (const FGameplayTag &Tag : ItemDef->DispelAnyTags)
+					{
+						if (Tag.ToString().Contains(TEXT("CC")))
+						{
+							bCriticalCC = true;
+							break;
+						}
+					}
+
+					SP->ReportCleanse(User, T, Removed, bCriticalCC, false, ItemDef->ItemId);
+				}
 			}
 		}
 	}

--- a/Source/JRPG/Private/Combat/SP/SynergyPointSubsystem.cpp
+++ b/Source/JRPG/Private/Combat/SP/SynergyPointSubsystem.cpp
@@ -1,0 +1,504 @@
+﻿// Source/JRPGCombat/Private/Combat/SP/SynergyPointSubsystem.cpp
+#include "Combat/SP/SynergyPointSubsystem.h"
+
+#include "Combat/Battle/BattleSessionSubsystem.h"
+#include "Combat/Chain/ChainAttackSubsystem.h"
+#include "Combat/Characters/CombatCharacterComponent.h"
+#include "Combat/Characters/CombatCharacterDataAsset.h"
+#include "Combat/Characters/CombatParticipantInterface.h"
+
+void USynergyPointSubsystem::OnWorldBeginPlay(UWorld &InWorld)
+{
+	Super::OnWorldBeginPlay(InWorld);
+
+	State = FSynergyPointState();
+	State.SPCap = Tuning.SPCap;
+	TryBindExternalEvents();
+}
+
+void USynergyPointSubsystem::TryBindExternalEvents()
+{
+	if (bSubscribed || !GetWorld())
+		return;
+	
+
+	if (UBattleSessionSubsystem* Battle = GetWorld()->GetSubsystem<UBattleSessionSubsystem>())
+	{
+		Battle->OnBattleEnded.AddUObject(this, &USynergyPointSubsystem::HandleBattleEnded);
+	}
+
+	if (UChainAttackSubsystem* Chain = GetWorld()->GetSubsystem<UChainAttackSubsystem>())
+	{
+		Chain->OnChainAttackEnded.AddUObject(this, &USynergyPointSubsystem::HandleChainEnded);
+	}
+
+	bSubscribed = true;
+}
+
+bool USynergyPointSubsystem::CanAcceptGain() const
+{
+	if (!GetWorld())
+		return false;
+
+	const UBattleSessionSubsystem* Battle = GetWorld()->GetSubsystem<UBattleSessionSubsystem>();
+	return Battle && Battle->IsBattleActive();
+}
+
+EPartyRole USynergyPointSubsystem::ResolveRoleForActor(AActor* Actor) const
+{
+	if (!Actor)
+		return EPartyRole::Attacker;
+
+	if (UCombatCharacterComponent* CC =Actor->FindComponentByClass<UCombatCharacterComponent>())
+	{
+		if (CC->CharacterDef)
+		{
+			return CC->CharacterDef->DefaultRole;
+		}
+	}
+
+	return EPartyRole::Attacker;
+}
+
+bool USynergyPointSubsystem::IsAlly(AActor* A,AActor* B) const
+{
+	if (!A||!B)
+		return false;
+
+	ICombatParticipantInterface* PA =Cast<ICombatParticipantInterface>(A);
+	ICombatParticipantInterface* PB =Cast<ICombatParticipantInterface>(B);
+	
+	if (!PA || !PB)
+		return false;
+
+	const ECombatTeam TA = PA->GetCombatTeam();
+	const ECombatTeam TB = PB->GetCombatTeam();
+	
+	if (TA == ECombatTeam::Neutral || TB == ECombatTeam::Neutral)
+		return false;
+
+	return TA == TB;
+}
+
+bool USynergyPointSubsystem::IsEnemy(AActor* A,AActor* B) const
+{
+	if (!A || !B)
+		return false;
+	
+	return !IsAlly(A, B);
+}
+
+int32 USynergyPointSubsystem::ComputeTacticalBonus(int32 RoleBonus,bool bFromTacticalReservation) const
+{
+	if (!bFromTacticalReservation || RoleBonus <= 0)
+		return 0;
+	
+
+	const int32 Scaled = FMath::CeilToInt((float)RoleBonus * Tuning.TacticalRoleBonusMultiplier);
+	return FMath::Max(0, Scaled - RoleBonus) + Tuning.TacticalFlatBonus;
+}
+
+bool USynergyPointSubsystem::PassesSameEventCooldown(const FString &EventKey,double Now)
+{
+	if (EventKey.IsEmpty())
+	{
+		return true;
+	}
+
+	if (const double *Found = LastSameEventRealByKey.Find(EventKey))
+	{
+		if ((Now - *Found) < (double)Tuning.SameEventCooldownSec)
+		{
+			return false;
+		}
+	}
+
+	LastSameEventRealByKey.Add(EventKey,Now);
+	return true;
+}
+
+int32 USynergyPointSubsystem::ConsumePerSecondBudget(int32 ProposedAmount,double Now)
+{
+	if (ProposedAmount <= 0)
+		return 0;
+
+	for (int32 i = RecentGainSlices.Num() - 1; i >= 0; --i)
+	{
+		if ((Now - RecentGainSlices[i].TimeReal) > 1.0)
+		{
+			RecentGainSlices.RemoveAt(i);
+		}
+	}
+
+	int32 Used = 0;
+	for (const FRecentGainSlice &Slice : RecentGainSlices)
+	{
+		Used += Slice.Amount;
+	}
+
+	const int32 RemainingBudget = FMath::Max(0,Tuning.SPMaxGainPerSec-Used);
+	const int32 Granted = FMath::Clamp(ProposedAmount,0,RemainingBudget);
+
+	if (Granted>0)
+	{
+		FRecentGainSlice NewSlice;
+		NewSlice.TimeReal = Now;
+		NewSlice.Amount = Granted;
+		RecentGainSlices.Add(NewSlice);
+	}
+
+	return Granted;
+}
+
+void USynergyPointSubsystem::UpdateReadyState()
+{
+	const bool bPrevReady = State.bChainReady;
+	State.SPCap = Tuning.SPCap;
+	State.bChainReady = (State.CurrentSP >= State.SPCap);
+
+	if (bPrevReady != State.bChainReady)
+	{
+		OnSynergyReadyChanged.Broadcast(State.bChainReady);
+	}
+}
+
+void USynergyPointSubsystem::ApplyGainEvent(FSPGainEvent &Event)
+{
+	if (!CanAcceptGain())
+		return;
+
+	const int32 Proposed = Event.BaseAmount + Event.RoleBonusAmount + Event.TacticalBonusAmount;
+	
+	if (Proposed <= 0)
+		return;
+	
+	const double Now = FPlatformTime::Seconds();
+	Event.TimestampReal = Now;
+	Event.FinalGrantedAmount =ConsumePerSecondBudget(Proposed, Now);
+	if (Event.FinalGrantedAmount <= 0)
+	{
+		return;
+	}
+
+	if (Tuning.bOvercapAllowed)
+	{
+		State.CurrentSP += Event.FinalGrantedAmount;
+	}
+	else
+	{
+		State.CurrentSP = FMath::Min(State.SPCap,State.CurrentSP + Event.FinalGrantedAmount);
+	}
+
+	State.LastGainRealTime = Now;
+	UpdateReadyState();
+
+	OnSynergyPointChanged.Broadcast(State.CurrentSP, Event.FinalGrantedAmount, Event.Type, Event.ReasonTag);
+	OnSynergyGainApplied.Broadcast(Event);
+}
+
+void USynergyPointSubsystem::ResetForBattleEnd(FName ReasonTag)
+{
+	const int32 Prev = State.CurrentSP;
+
+	State.CurrentSP = 0;
+	State.LastGainRealTime = FPlatformTime::Seconds();
+	
+	RecentGainSlices.Reset();
+	LastSameEventRealByKey.Reset();
+	DamageWindows.Reset();
+	
+	UpdateReadyState();
+
+	if (Prev > 0)
+	{
+		OnSynergyPointChanged.Broadcast(State.CurrentSP, -Prev, ESPEventType::None, ReasonTag);
+	}
+}
+
+void USynergyPointSubsystem::ResetForChainEnd(FName ReasonTag)
+{
+	const int32 Prev =State.CurrentSP;
+
+	State.CurrentSP = 0;
+	State.LastGainRealTime = FPlatformTime::Seconds();
+	RecentGainSlices.Reset();
+	UpdateReadyState();
+
+	if (Prev > 0)
+	{
+		OnSynergyPointChanged.Broadcast(State.CurrentSP,-Prev, ESPEventType::None,ReasonTag);
+	}
+}
+
+void USynergyPointSubsystem::HandleBattleEnded(const FBattleSessionSnapshot &, EBattleEndReason)
+{
+	ResetForBattleEnd("SP.Reset.BattleEnd");
+}
+
+void USynergyPointSubsystem::HandleChainEnded(const FChainAttackSnapshot &)
+{
+	ResetForChainEnd("SP.Reset.ChainEnd");
+}
+
+void USynergyPointSubsystem::ReportDamage(AActor *Instigator, AActor *Target,
+	float DamageAmount, bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator || !Target || DamageAmount <= 0.f)
+		return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = Target;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Damage;
+	Evt.BaseAmount = 1 + FMath::FloorToInt(DamageAmount / 100.f);
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	if (Evt.Role == EPartyRole::Attacker)
+	{
+		FDamageWindowRuntime &W = DamageWindows.FindOrAdd(Instigator);
+		const double Now = FPlatformTime::Seconds();
+
+		if ((Now - W.WindowStartReal) > (double)Tuning.AttackerDamageWindowSec)
+		{
+			W.WindowStartReal = Now;
+			W.AccDamage = DamageAmount;
+		}
+		else
+		{
+			W.AccDamage += DamageAmount;
+		}
+
+		const FString CoolKey = FString::Printf(TEXT("SP.Attacker.DamageWindow.%s"), *Instigator->GetName());
+
+		if (W.AccDamage >= Tuning.AttackerDamageWindowThreshold && PassesSameEventCooldown(CoolKey,Now))
+		{
+			Evt.RoleBonusAmount += Tuning.AttackerDamageWindowBonus;
+			W.AccDamage = 0.f;
+			W.WindowStartReal = Now;
+		}
+	}
+
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportHeal(AActor *Instigator, AActor *Target,
+	float HealAmount, float TargetHPRatioBefore, bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator || !Target || HealAmount <= 0.f)
+		return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = Target;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Heal;
+	Evt.BaseAmount = 1 + FMath::FloorToInt(HealAmount / 120.f);
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	if (Evt.Role == EPartyRole::Supporter && TargetHPRatioBefore <= Tuning.SupporterCriticalHealThreshold)
+	{
+		Evt.RoleBonusAmount += Tuning.SupporterCriticalHealBonus;
+	}
+
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportBreak(AActor*Instigator, AActor*Target,
+	float BreakAmount, bool bTriggeredStun, bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator || !Target) return;
+	if (BreakAmount <= 0.f && !bTriggeredStun) return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = Target;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Break;
+	Evt.BaseAmount = (BreakAmount > 0.f) ? 1 : 0;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	if (Evt.Role == EPartyRole::Attacker)
+	{
+		if (BreakAmount > 0.f)
+		{
+			Evt.RoleBonusAmount += FMath::FloorToInt(BreakAmount * Tuning.AttackerBreakContributionCoeff);
+		}
+
+		if (bTriggeredStun)
+		{
+			const double Now = FPlatformTime::Seconds();
+			const FString CoolKey = FString::Printf(TEXT("SP.Attacker.Stun.%s.%s"),
+							*Instigator->GetName(),
+							*Target->GetName());
+
+			if (PassesSameEventCooldown(CoolKey,Now))
+			{
+				Evt.RoleBonusAmount += Tuning.AttackerStunTriggerBonus;
+			}
+		}
+	}
+
+	Evt.TacticalBonusAmount =ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportBuff(AActor *Instigator, AActor *Target, FName BuffId,
+	bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator || !Target || BuffId.IsNone()) return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = Target;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Buff;
+	Evt.BaseAmount = 1;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	if (Evt.Role == EPartyRole::Supporter && IsAlly(Instigator,Target))
+	{
+		const double Now = FPlatformTime::Seconds();
+		const FString CoolKey = FString::Printf(TEXT("SP.Supporter.Buff.%s.%s"),
+					*Instigator->GetName(),
+					*BuffId.ToString());
+
+		if (PassesSameEventCooldown(CoolKey, Now))
+		{
+			Evt.RoleBonusAmount += Tuning.SupporterBuffUptimeBonus;
+		}
+	}
+
+	Evt.TacticalBonusAmount =ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportDebuff(AActor *Instigator, AActor *Target, FName DebuffId,
+	bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator || !Target || DebuffId.IsNone()) 
+		return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = Target;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Debuff;
+	Evt.BaseAmount = 1;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	// 문서상 Debuff는 기본 획득에 포함되지만 별도 롤 보너스 계수는 고정되어 있지 않으므로
+	// 현재는 Base Gain만 준다.
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportCleanse(AActor *Instigator, AActor *Target,
+	int32 RemovedCount, bool bRemovedCriticalCC, bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator || !Target || RemovedCount <= 0)
+		return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = Target;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Cleanse;
+	Evt.BaseAmount = 1;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	if (Evt.Role == EPartyRole::Supporter && bRemovedCriticalCC)
+	{
+		Evt.RoleBonusAmount += Tuning.SupporterCleanseBonus;
+	}
+
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount,bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportThreatOutcome(AActor* Instigator, AActor* EnemyOwner,
+	float ThreatDelta, bool bBecameTopThreat, bool bRescuedAlly, bool bFromTacticalReservation, FName ReasonTag)
+{
+	if (!Instigator||!EnemyOwner||ThreatDelta<=0.f)return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Instigator;
+	Evt.Target = EnemyOwner;
+	Evt.Role = ResolveRoleForActor(Instigator);
+	Evt.Type = ESPEventType::Taunt;
+	Evt.BaseAmount = 1;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+
+	if (Evt.Role == EPartyRole::Defender)
+	{
+		if (bRescuedAlly)
+		{
+			Evt.RoleBonusAmount += Tuning.DefenderAggroRescueBonus;
+		}
+		else if (bBecameTopThreat)
+		{
+			Evt.RoleBonusAmount += Tuning.DefenderAggroHoldBonus;
+		}
+	}
+
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount,bFromTacticalReservation);
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportAggroHold(AActor* Defender, AActor* EnemyOwner,
+	bool bFromTacticalReservation,FName ReasonTag)
+{
+	if (!Defender || !EnemyOwner)
+		return;
+
+	const double Now = FPlatformTime::Seconds();
+	const FString CoolKey = FString::Printf(TEXT("SP.Defender.Hold.%s.%s"),
+			*Defender->GetName(),
+			*EnemyOwner->GetName());
+
+	if (!PassesSameEventCooldown(CoolKey, Now))
+		return;
+	
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Defender;
+	Evt.Target = EnemyOwner;
+	Evt.Role = ResolveRoleForActor(Defender);
+	Evt.Type = ESPEventType::Taunt;
+	Evt.BaseAmount = 0;
+	Evt.RoleBonusAmount = (Evt.Role == EPartyRole::Defender) ? Tuning.DefenderAggroHoldBonus : 0;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+
+	ApplyGainEvent(Evt);
+}
+
+void USynergyPointSubsystem::ReportPartyProtect(AActor* Defender,AActor* ProtectedTarget,
+	bool bFromTacticalReservation,FName ReasonTag)
+{
+	if (!Defender || !ProtectedTarget)
+		return;
+
+	FSPGainEvent Evt;
+	Evt.Instigator = Defender;
+	Evt.Target = ProtectedTarget;
+	Evt.Role = ResolveRoleForActor(Defender);
+	Evt.Type = ESPEventType::Protect;
+	Evt.BaseAmount = 1;
+	Evt.RoleBonusAmount = (Evt.Role == EPartyRole::Defender) ? Tuning.DefenderPartyProtectBonus : 0;
+	Evt.bFromTacticalReservation = bFromTacticalReservation;
+	Evt.ReasonTag = ReasonTag;
+	Evt.TacticalBonusAmount = ComputeTacticalBonus(Evt.RoleBonusAmount, bFromTacticalReservation);
+
+	ApplyGainEvent(Evt);
+}

--- a/Source/JRPG/Private/Combat/Skills/SkillComponent.cpp
+++ b/Source/JRPG/Private/Combat/Skills/SkillComponent.cpp
@@ -1,17 +1,21 @@
-﻿#include "Combat/Skills/SkillComponent.h"
+﻿#include "JRPG/Public/Combat/Skills/SkillComponent.h"
+#include "JRPG/Public/Combat/Skills/SkillDataAsset.h"
 
-#include "Combat/Battle/CombatFormulaLibrary.h"
-#include "Combat/Characters/CombatParticipantInterface.h"
-#include "Combat/Characters/Stats/CombatStatsComponent.h"
+#include "JRPG/Public/Combat/Battle/CombatFormulaLibrary.h"
+#include "JRPG/Public/Combat/Characters/CombatParticipantInterface.h"
+#include "JRPG/Public/Combat/Characters/Stats/CombatStatsComponent.h"
 
-#include "Combat/Stats/HPComponent.h"
-#include "Combat/Stats/APComponent.h"
-#include "Combat/SP/SPComponent.h"
+#include "JRPG/Public/Combat/Stats/HPComponent.h"
+#include "JRPG/Public/Combat/Stats/APComponent.h"
+#include "JRPG/Public/Combat/SP/SPComponent.h"
+#include "JRPG/Public/Combat/SP/SynergyPointSubsystem.h"
 
-#include "Combat/Status/StatusEffectComponent.h"
-#include "Combat/Status/StatusEffectDataAsset.h"
-#include "Combat/Groggy/GroggyComponent.h"
-#include "Combat/Threat/ThreatComponent.h"
+#include "JRPG/Public/Combat/Status/CombatStatusCleanseInterface.h"
+#include "JRPG/Public/Combat/Status/StatusEffectComponent.h"
+#include "JRPG/Public/Combat/Status/StatusEffectDataAsset.h"
+#include "JRPG/Public/Combat/Groggy/GroggyComponent.h"
+#include "JRPG/Public/Combat/Threat/ThreatComponent.h"
+#include "JRPG/Public/Combat/Skills/SkillTypes.h"
 
 USkillComponent::USkillComponent()
 {
@@ -27,7 +31,7 @@ void USkillComponent::BeginPlay()
 	AP = GetOwner() ? GetOwner()->FindComponentByClass<UAPComponent>() : nullptr;
 	SP = GetOwner() ? GetOwner()->FindComponentByClass<USPComponent>() : nullptr;
 
-	for (USkillDataAsset*S : KnownSkills)
+	for (USkillDataAsset *S : KnownSkills)
 	{
 		if (S && S->IsValidSkill() && !Cooldowns.Contains(S->SkillId))
 			Cooldowns.Add(S->SkillId, 0.f);
@@ -78,7 +82,8 @@ float USkillComponent::GetCooldownRemaining(FName SkillId) const
 
 bool USkillComponent::IsHostileTarget(AActor *Target)const
 {
-	if (!GetOwner() || !Target)returnfalse;
+	if (!GetOwner() || !Target)
+		return false;
 
 	ICombatParticipantInterface *A =Cast<ICombatParticipantInterface>(GetOwner());
 	ICombatParticipantInterface *T =Cast<ICombatParticipantInterface>(Target);
@@ -117,9 +122,9 @@ FSkillCastResult USkillComponent::ValidateCast(const USkillDataAsset &Skill,cons
 	return FSkillCastResult::Ok();
 }
 
-FSkillCastResult USkillComponent::PrepareSkillCast(FName SkillId,const TArray<AActor*>&Targets, bool bFromTacticalReservation, FName ReasonTag)
+FSkillCastResult USkillComponent::PrepareSkillCast(FName SkillId, const TArray<AActor*>&Targets, bool bFromTacticalReservation, FName ReasonTag)
 {
-	USkillDataAsset*Skill =GetSkillDef(SkillId);
+	USkillDataAsset* Skill = GetSkillDef(SkillId);
 	if (!Skill)
 		return FSkillCastResult::Fail("Reject.SkillNotFound");
 
@@ -152,11 +157,11 @@ FSkillCastResult USkillComponent::PrepareSkillCast(FName SkillId,const TArray<AA
 			Prepared.Targets.Add(T);
 	}
 
-	bHasPrepared =true;
+	bHasPrepared = true;
 	return FSkillCastResult::Ok();
 }
 
-void USkillComponent::ApplySkillEffects(const USkillDataAsset&Skill, const TArray<AActor*>&Targets, bool bFromTacticalReservation)
+void USkillComponent::ApplySkillEffects(const USkillDataAsset &Skill, const TArray<AActor*>&Targets, bool bFromTacticalReservation)
 {
 	const float Atk = Stats.IsValid() ? Stats->GetSnapshot().Attack : 10.f;
 	const float CritRate = Stats.IsValid() ? Stats->GetSnapshot().CritRate : 0.f;
@@ -171,38 +176,51 @@ void USkillComponent::ApplySkillEffects(const USkillDataAsset&Skill, const TArra
 		UCombatStatsComponent* TStats = T->FindComponentByClass<UCombatStatsComponent>();
 		UThreatComponent* TThreat = T->FindComponentByClass<UThreatComponent>();
 		UGroggyComponent* TGroggy = T->FindComponentByClass<UGroggyComponent>();
-		UStatusEffectComponent *TStatus = T->FindComponentByClass<UStatusEffectComponent>();
-
+		UStatusEffectComponent* TStatus = T->FindComponentByClass<UStatusEffectComponent>();
+		USynergyPointSubsystem* SP = GetWorld() ? GetWorld()->GetSubsystem<USynergyPointSubsystem>() : nullptr;
+		
 		float DamageDone = 0.f;
 
-		if (THP && (Skill.BasePower>0.f || Skill.AttackScale > 0.f))
+		if (THP && (Skill.BasePower > 0.f || Skill.AttackScale > 0.f))
 		{
 			const float Def = TStats ? TStats->GetSnapshot().Defense : 5.f;
 
 			const FDamageBreakdown B = UCombatFormulaLibrary::BuildDamage(
-			Atk,Def,
-			Skill.BasePower,
-			Skill.AttackScale,
-			Skill.DefenseScale,
-			1.0f,
-			Skill.bAllowCrit,
-			CritRate,
-			CritBonus,
-			Skill.VarianceMin,
-			Skill.VarianceMax,
-			Skill.GroggyPower,
-			1.0f
+				Atk,Def,
+				Skill.BasePower,
+				Skill.AttackScale,
+				Skill.DefenseScale,
+				1.0f,
+				Skill.bAllowCrit,
+				CritRate,
+				CritBonus,
+				Skill.VarianceMin,
+				Skill.VarianceMax,
+				Skill.GroggyPower,
+				1.0f
 						);
 
 			DamageDone = B.FinalDamage;
-			THP->ApplyDamage(DamageDone,GetOwner(), Skill.SkillId);
+			
+			if (SP && DamageDone>0.f)
+			{
+				SP->ReportDamage(GetOwner(),T, DamageDone,bFromTacticalReservation, Skill.SkillId);
+			}
+			
+			//THP->ApplyDamage(DamageDone,GetOwner(), Skill.SkillId);
 
 			if (IsHostileTarget(T))
 			{
-				if (TGroggy&&Skill.GroggyPower > 0.f)
+				if (TGroggy && Skill.GroggyPower > 0.f)
 				{
 					TGroggy->AddGroggyDamage(B.GroggyDamage,GetOwner(), Skill.SkillId);
 				}
+				
+				if (SP && Skill.GroggyPower > 0.f)
+				{
+					SP->ReportBreak(GetOwner(),T, B.GroggyDamage,false, bFromTacticalReservation, Skill.SkillId);
+				}
+				
 				if (TThreat)
 				{
 					const float Threat = FMath::Max(0.f,Skill.ThreatBase+DamageDone* FMath::Max(0.f,Skill.ThreatFromDamageMul));
@@ -211,16 +229,77 @@ void USkillComponent::ApplySkillEffects(const USkillDataAsset&Skill, const TArra
 				}
 			}
 		}
+		
+		const float BeforeRatio = THP ? (THP->GetMaxHP() > 0.f ? (THP->GetHP() / THP->GetMaxHP()) : 1.f) :1.f;
+		if (SP && Skill.HealPower > 0.f)
+		{
+			const float BeforeHP = THP->GetHP();
+			THP->Heal(Skill.HealPower,GetOwner(), Skill.SkillId);
+			const float Healed = FMath::Max(0.f,THP->GetHP() - BeforeHP);
 
+			if (Healed > 0.f)
+			{
+				SP->ReportHeal(GetOwner(),T, Healed, BeforeRatio, bFromTacticalReservation, Skill.SkillId);
+			}
+		}
+
+		
+		if (TStatus && Skill.ApplyStatus && FMath::FRand() <= FMath::Clamp(Skill.StatusChance,0.f,1.f))
+		{
+			TStatus->ApplyStatus(Skill.ApplyStatus,GetOwner(), Skill.StatusStacks, Skill.SkillId);
+			
+			if (SP)
+			{
+				if (IsHostileTarget(T))
+				{
+					SP->ReportDebuff(GetOwner(),T,Skill.ApplyStatus->StatusId, bFromTacticalReservation,Skill.SkillId);
+				}
+				else
+				{
+					SP->ReportBuff(GetOwner(),T,Skill.ApplyStatus->StatusId, bFromTacticalReservation,Skill.SkillId);
+				}
+			}
+		}
+		
+		if (TStatus && Skill.DispelAnyTags.Num() > 0)
+		{
+			if (ICombatStatusCleanseInterface* Cleanse = Cast<ICombatStatusCleanseInterface>(TStatus))
+			{
+				const int32 Removed = Cleanse->RemoveStatusesByAnyTags(
+					Skill.DispelAnyTags,
+					Skill.DispelRemoveCount,
+					GetOwner(),
+					Skill.SkillId);
+
+				if (SP&&Removed>0)
+				{
+					bool bCriticalCC = false;
+					for (const FGameplayTag&Tag : Skill.DispelAnyTags)
+					{
+						if (Tag.ToString().Contains(TEXT("CC")))
+						{
+							bCriticalCC =true;
+							break;
+						}
+					}
+
+					SP->ReportCleanse(GetOwner(),T,Removed,bCriticalCC,bFromTacticalReservation,Skill.SkillId);
+				}
+			}
+		}
+			
+		
+		/*
 		if (THP && Skill.HealPower > 0.f)
 		{
 			THP->Heal(Skill.HealPower,GetOwner(), Skill.SkillId);
 		}
-
-		if (TStatus && Skill.ApplyStatus&& FMath::FRand()<= FMath::Clamp(Skill.StatusChance,0.f,1.f))
+		
+		if (TStatus && Skill.ApplyStatus && FMath::FRand() <= FMath::Clamp(Skill.StatusChance,0.f,1.f))
 		{
 			TStatus->ApplyStatus(Skill.ApplyStatus,GetOwner(), Skill.StatusStacks, Skill.SkillId);
 		}
+		*/
 	}
 
 	OnSkillResolvedDetailed.Broadcast(Skill.SkillId, GetOwner(), Targets.Num(), bFromTacticalReservation);

--- a/Source/JRPG/Private/Combat/Skills/SkillDataAsset.cpp
+++ b/Source/JRPG/Private/Combat/Skills/SkillDataAsset.cpp
@@ -1,1 +1,1 @@
-﻿#include "Combat/Skills/SkillDataAsset.h"
+﻿#include "JRPG/Public/Combat/Skills/SkillDataAsset.h"

--- a/Source/JRPG/Private/Combat/Threat/ThreatComponent.cpp
+++ b/Source/JRPG/Private/Combat/Threat/ThreatComponent.cpp
@@ -1,4 +1,5 @@
-﻿#include "Combat/Threat/ThreatComponent.h"
+﻿#include "JRPG/Public/Combat/Threat/ThreatComponent.h"
+#include "JRPG/Public/Combat/SP/SynergyPointSubsystem.h"
 
 UThreatComponent::UThreatComponent()
 {
@@ -22,7 +23,8 @@ int32 UThreatComponent::FindIndex(AActor *Source) const
 
 void UThreatComponent::AddThreat(AActor *Source, float Amount, FName)
 {
-	if (!Source || Amount<=0.f) return;
+	if (!Source || Amount <= 0.f) 
+		return;
 
 	const double Now = FPlatformTime::Seconds();
 	const int32 Idx = FindIndex(Source);
@@ -37,8 +39,32 @@ void UThreatComponent::AddThreat(AActor *Source, float Amount, FName)
 	else
 	{
 		Table[Idx].Threat += Amount;
-		Table[Idx].LastUpdateReal =Now;
+		Table[Idx].LastUpdateReal = Now;
 	}
+	
+	AActor* PrevTarget = GetTopThreatSource(); //PreviousTargetActor;
+	AActor* NewTarget = CurrentTarget.Get();
+
+	if (USynergyPointSubsystem *SP = GetWorld() ? GetWorld()->GetSubsystem<USynergyPointSubsystem>() : nullptr)
+	{
+		const bool bBecameTopThreat = (NewTarget == Source);
+		const bool bRescuedAlly = bBecameTopThreat&&PrevTarget && PrevTarget != Source;
+
+		//Delta가 인자가 아니라서 일단 Amount로 대체했음.
+		//SourceActor변수도 Source로 대체
+		if (Amount > 0.f)
+		{
+			SP->ReportThreatOutcome(
+				Source,
+				GetOwner(),// 적 본체
+				Amount,
+				bBecameTopThreat,
+				bRescuedAlly,
+				false,
+				ActionTag);
+		}
+	}
+	
 	OnThreatTableChanged.Broadcast(GetOwner());
 }
 

--- a/Source/JRPG/Public/Combat/Groggy/GroggyComponent.h
+++ b/Source/JRPG/Public/Combat/Groggy/GroggyComponent.h
@@ -25,7 +25,7 @@ public:
 
 	FOnGroggyStateChanged OnGroggyStateChanged;
 
-	void AddGroggyDamage(float Amount,AActor *Source,FName ReasonTag);
+	void AddGroggyDamage(float Amount, AActor* SourceActor, FName ReasonTag, bool bFromTacticalReservation = false);
 	void ResetGauge(FName ReasonTag);
 
 protected:
@@ -40,6 +40,9 @@ private:
 	UPROPERTY() TObjectPtr<UGroggyModSourceObject> ModSource = nullptr;
 
 	TWeakObjectPtr<class UCombatStatsComponent> Stats;
+	
+	TWeakObjectPtr<AActor> LastBreakSource;
+	bool bLastBreakFromTacticalReservation = false;
 
 	void EnterGroggy();
 	void ExitGroggy();

--- a/Source/JRPG/Public/Combat/SP/SynergyPointSubsystem.h
+++ b/Source/JRPG/Public/Combat/SP/SynergyPointSubsystem.h
@@ -1,0 +1,103 @@
+﻿// Source/JRPGCombat/Public/Combat/SP/SynergyPointSubsystem.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+
+#include "Combat/SP/SynergyPointTypes.h"
+#include "Combat/Battle/BattleSessionTypes.h"
+#include "Combat/Chain/ChainAttackTypes.h"
+
+#include "SynergyPointSubsystem.generated.h"
+
+UCLASS()
+class JRPG_API USynergyPointSubsystem : public UWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	FOnSynergyPointChanged OnSynergyPointChanged;
+	FOnSynergyReadyChanged OnSynergyReadyChanged;
+	FOnSynergyGainApplied OnSynergyGainApplied;
+
+	const FSynergyPointState& GetState() const	 { return State; }
+	FSynergyPointTuning& GetMutableTuning()		 { return Tuning; }
+	const FSynergyPointTuning& GetTuning() const { return Tuning; }
+
+	bool IsChainReady()const {return State.bChainReady; }
+
+	void ResetForBattleEnd(FName ReasonTag);
+	void ResetForChainEnd(FName ReasonTag);
+
+	void ReportDamage(AActor *Instigator, AActor *Target,
+		float DamageAmount, bool bFromTacticalReservation,FName ReasonTag);
+
+	void ReportHeal(AActor *Instigator, AActor *Target,
+		float HealAmount, float TargetHPRatioBefore, bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportBreak(AActor *Instigator, AActor *Target,
+		float BreakAmount, bool bTriggeredStun, bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportBuff(AActor *Instigator, AActor *Target, FName BuffId,
+		bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportDebuff(AActor *Instigator, AActor *Target, FName DebuffId,
+		bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportCleanse(AActor *Instigator, AActor *Target, 
+		int32 RemovedCount, bool bRemovedCriticalCC, bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportThreatOutcome(AActor*Instigator, AActor*EnemyOwner,
+		float ThreatDelta, bool bBecameTopThreat, bool bRescuedAlly, bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportAggroHold(AActor *Defender, AActor *EnemyOwner,
+		bool bFromTacticalReservation, FName ReasonTag);
+
+	void ReportPartyProtect(AActor *Defender, AActor *ProtectedTarget,
+		bool bFromTacticalReservation, FName ReasonTag);
+
+protected:
+	virtual void OnWorldBeginPlay(UWorld &InWorld) override;
+
+private:
+	UPROPERTY() 
+	FSynergyPointState State;
+	
+	UPROPERTY(EditAnywhere)
+	FSynergyPointTuning Tuning;
+
+	struct FRecentGainSlice
+	{
+		double TimeReal = 0.0;
+		int32 Amount = 0;
+	};
+
+	struct FDamageWindowRuntime
+	{
+		double WindowStartReal = 0.0;
+		float AccDamage = 0.f;
+	};
+
+	TArray<FRecentGainSlice> RecentGainSlices;
+	TMap<FString, double> LastSameEventRealByKey;
+	TMap<TWeakObjectPtr<AActor>, FDamageWindowRuntime> DamageWindows;
+
+	bool bSubscribed = false;
+
+	bool CanAcceptGain() const;
+	void TryBindExternalEvents();
+
+	EPartyRole ResolveRoleForActor(AActor *Actor) const;
+	bool IsAlly(AActor *A, AActor *B) const;
+	bool IsEnemy(AActor *A, AActor *B) const;
+
+	int32 ComputeTacticalBonus(int32 RoleBonus,bool bFromTacticalReservation) const;
+	bool PassesSameEventCooldown(const FString &EventKey, double Now);
+	int32 ConsumePerSecondBudget(int32 ProposedAmount, double Now);
+
+	void ApplyGainEvent(FSPGainEvent &Event);
+	void UpdateReadyState();
+
+	void HandleBattleEnded(const FBattleSessionSnapshot &Snapshot,EBattleEndReason Reason);
+	void HandleChainEnded(const FChainAttackSnapshot &Snapshot);
+};

--- a/Source/JRPG/Public/Combat/SP/SynergyPointTypes.h
+++ b/Source/JRPG/Public/Combat/SP/SynergyPointTypes.h
@@ -1,0 +1,90 @@
+﻿// Source/JRPGCombat/Public/Combat/SP/SynergyPointTypes.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Combat/Core/RoleTypes.h"
+#include "SynergyPointTypes.generated.h"
+
+UENUM()
+enum class ESPEventType : uint8
+{
+	None,
+	Damage,
+	Heal,
+	Taunt,
+	Cleanse,
+	Buff,
+	Debuff,
+	Break,
+	Protect
+};
+
+USTRUCT()
+struct FSynergyPointState
+{
+	GENERATED_BODY()
+
+	UPROPERTY() int32 CurrentSP = 0;
+	UPROPERTY() int32 SPCap = 100;
+	UPROPERTY() bool bChainReady = false;
+	UPROPERTY() double LastGainRealTime = 0.0;
+};
+
+USTRUCT()
+struct FSPGainEvent
+{
+	GENERATED_BODY()
+
+	UPROPERTY() TWeakObjectPtr<AActor> Instigator;
+	UPROPERTY() TWeakObjectPtr<AActor> Target;
+
+	UPROPERTY() EPartyRole Role = EPartyRole::Attacker;
+	UPROPERTY() ESPEventType Type = ESPEventType::None;
+
+	UPROPERTY() int32 BaseAmount = 0;
+	UPROPERTY() int32 RoleBonusAmount = 0;
+	UPROPERTY() int32 TacticalBonusAmount = 0;
+	UPROPERTY() int32 FinalGrantedAmount = 0;
+
+	UPROPERTY() bool bFromTacticalReservation = false;
+	UPROPERTY() double TimestampReal = 0.0;
+
+	UPROPERTY() FName ReasonTag = NAME_None;
+};
+
+USTRUCT()
+struct FSynergyPointTuning
+{
+	GENERATED_BODY()
+
+	// 문서상 상세 수치는 TBD이므로, 여기 값은 “기본 안전값”이다.
+	UPROPERTY(EditAnywhere) int32 SPCap = 100;
+	UPROPERTY(EditAnywhere) int32 SPMaxGainPerSec = 25;
+	UPROPERTY(EditAnywhere) float SameEventCooldownSec = 1.5f;
+
+	UPROPERTY(EditAnywhere) float TacticalRoleBonusMultiplier = 1.25f;
+	UPROPERTY(EditAnywhere) int32 TacticalFlatBonus = 0;
+	UPROPERTY(EditAnywhere) bool bOvercapAllowed = true;
+
+	// Defender
+	UPROPERTY(EditAnywhere) int32 DefenderAggroHoldBonus = 6;
+	UPROPERTY(EditAnywhere) int32 DefenderAggroRescueBonus = 12;
+	UPROPERTY(EditAnywhere) int32 DefenderPartyProtectBonus = 8;
+
+	// Attacker
+	UPROPERTY(EditAnywhere) float AttackerBreakContributionCoeff = 0.20f;
+	UPROPERTY(EditAnywhere) int32 AttackerStunTriggerBonus = 12;
+	UPROPERTY(EditAnywhere) float AttackerDamageWindowSec = 1.0f;
+	UPROPERTY(EditAnywhere) float AttackerDamageWindowThreshold = 120.f;
+	UPROPERTY(EditAnywhere) int32 AttackerDamageWindowBonus = 8;
+
+	// Supporter
+	UPROPERTY(EditAnywhere) float SupporterCriticalHealThreshold = 0.30f;
+	UPROPERTY(EditAnywhere) int32 SupporterCriticalHealBonus = 10;
+	UPROPERTY(EditAnywhere) int32 SupporterCleanseBonus = 10;
+	UPROPERTY(EditAnywhere) int32 SupporterBuffUptimeBonus = 4;
+};
+
+DECLARE_MULTICAST_DELEGATE_FourParams(FOnSynergyPointChanged, int32/*CurrentSP*/, int32/*Delta*/, ESPEventType/*Type*/, FName/*ReasonTag*/);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnSynergyReadyChanged,bool/*bReady*/);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnSynergyGainApplied,constFSPGainEvent&/*Event*/);

--- a/Source/JRPG/Public/Combat/Skills/SkillComponent.h
+++ b/Source/JRPG/Public/Combat/Skills/SkillComponent.h
@@ -1,8 +1,8 @@
 ﻿#pragma once
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Combat/Skills/SkillDataAsset.h"
-#include "Combat/Skills/SkillTypes.h"
+#include "JRPG/Public/Combat/Skills/SkillDataAsset.h"
+#include "JRPG/Public/Combat/Skills/SkillTypes.h"
 #include "SkillComponent.generated.h"
 
 DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnSkillCast, FName /*SkillId*/, AActor* /*Caster*/, int32 /*TargetCount*/);

--- a/Source/JRPG/Public/Combat/Skills/SkillDataAsset.h
+++ b/Source/JRPG/Public/Combat/Skills/SkillDataAsset.h
@@ -1,8 +1,9 @@
 ﻿#pragma once
 #include "CoreMinimal.h"
 #include "Engine/PrimaryDataAsset.h"
+#include "GameplayTagContainer.h"
 #include "Animation/AnimMontage.h"
-#include "Combat/Skills/SkillTypes.h"
+#include "JRPG/Public/Combat/Skills/SkillTypes.h"
 #include "Combat/Presentation/CombatPresentationTypes.h"
 #include "SkillDataAsset.generated.h"
 
@@ -47,5 +48,8 @@ public:
 	UPROPERTY(EditAnywhere) FName HitCueTag = "Skill.Hit";
 	UPROPERTY(EditAnywhere) FName FinishCueTag = "Skill.Finish";
 
+	UPROPERTY(EditAnywhere) FGameplayTagContainer DispelAnyTags;
+	UPROPERTY(EditAnywhere) int32 DispelRemoveCount =0;// <=0 means all
+	
 	bool IsValidSkill()const { return !SkillId.IsNone(); }
 };

--- a/Source/JRPG/Public/Combat/Threat/ThreatComponent.h
+++ b/Source/JRPG/Public/Combat/Threat/ThreatComponent.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Combat/Threat/ThreatTypes.h"
+#include "JRPG/Public/Combat/Threat/ThreatTypes.h"
 #include "ThreatComponent.generated.h"
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnThreatTableChanged, AActor* /*Owner*/);
@@ -25,7 +25,7 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
-	virtual void TickComponent(floatDeltaTime, ELevelTickTickType, FActorComponentTickFunction *ThisTickFunction) override;
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction *ThisTickFunction) override;
 
 private:
 	UPROPERTY() TArray<FThreatEntry> Table;


### PR DESCRIPTION
# 수정(패치) 못한 부분

### Hold 윈도우 만족 지점 패치

> 예: `TargetHoldSec`가 지나도 CurrentTarget이 탱커면 보너스.
>
>
> 이 부분은 현재 ThreatComponent의 락/홀드 타이머 변수명에 맞춰 넣으면 됨.
>

```cpp
if (bHoldWindowSatisfied&&CurrentTarget.IsValid())
 {
if (USynergyPointSubsystem*SP =GetWorld() ?GetWorld()->GetSubsystem<USynergyPointSubsystem>() :nullptr)
  {
SP->ReportAggroHold(CurrentTarget.Get(),GetOwner(),false,"Threat.Hold");
  }
 }
```

- 틱마다 수치 감소시키는 관리를 하는건 알겠으나, 타겟 유지 관련해서는 어디에 들어가야할지 모르겠음.

다른 코드들은 완료.