### PR TITLE
[#102] 허브 부활 위치 수정

### DIFF
--- a/Source/JRPG/Private/Game/HubSubsystem.cpp
+++ b/Source/JRPG/Private/Game/HubSubsystem.cpp
@@ -1,7 +1,5 @@
 #include "Game/HubSubsystem.h"
 
-#include "Game/HubActor.h"
-
 // ==== 허브 등록 ====
 void UHubSubsystem::RegisterHub(AActor* HubActor)
 {
@@ -25,6 +23,7 @@ void UHubSubsystem::UnregisterHub(AActor* HubActor)
 	if (LastVisitedHub.Get() == HubActor)
 	{
 		LastVisitedHub = nullptr;
+		LastVisitedLocation = FVector::ZeroVector;
 	}
 
 	UE_LOG(LogTemp, Log, TEXT("HubSubsystem : 허브 해제 - %s"), *GetNameSafe(HubActor));
@@ -53,11 +52,12 @@ AActor* UHubSubsystem::GetFocusedHub() const
 }
 
 // ==== 마지막 방문 허브 ====
-void UHubSubsystem::VisitHub(AActor* HubActor)
+void UHubSubsystem::VisitHub(AActor* HubActor, const FVector& PlayerLocation)
 {
 	if (!HubActor) return;
 	LastVisitedHub = HubActor;
-	UE_LOG(LogTemp, Log, TEXT("HubSubsystem : 마지막 방문 허브 등록 - %s"), *GetNameSafe(HubActor));
+	LastVisitedLocation = PlayerLocation;
+	UE_LOG(LogTemp, Log, TEXT("HubSubsystem : 마지막 방문 허브 등록 - %s (플레이어 위치: %s)"), *GetNameSafe(HubActor), *PlayerLocation.ToString());
 }
 
 bool UHubSubsystem::HasLastVisitedHub() const
@@ -68,9 +68,10 @@ bool UHubSubsystem::HasLastVisitedHub() const
 // ==== 리스폰 위치 ====
 FVector UHubSubsystem::GetRespawnLocation(const FVector& FallbackOrigin) const
 {
-	if (AActor* Hub = LastVisitedHub.Get())
+	// 마지막 방문 허브가 유효하면 -> E키 상호작용 시점의 플레이어 위치 반환
+	if (LastVisitedHub.IsValid())
 	{
-		return Hub->GetActorLocation();
+		return LastVisitedLocation;
 	}
 
 	// 마지막 방문 허브가 없으면 가장 가까운 허브로 폴백

--- a/Source/JRPG/Private/Game/JRPGPlayerController.cpp
+++ b/Source/JRPG/Private/Game/JRPGPlayerController.cpp
@@ -273,10 +273,19 @@ void AJRPGPlayerController::OnInteract()
 	{
 		if (AActor* FocusedHub = HubSub->GetFocusedHub())
 		{
-			HubSub->VisitHub(FocusedHub);
+			// 허브 액터 위치가 아닌 플레이어의 현재 위치를 리스폰 좌표로 저장
+			APawn* PlayerPawn = GetPawn();
+			if (!PlayerPawn)
+			{
+				UE_LOG(LogTemp, Warning, TEXT("JRPGPlayerController::OnInteract : Pawn이 없어 허브 방문 등록 불가"));
+				return;
+			}
+
+			HubSub->VisitHub(FocusedHub, PlayerPawn->GetActorLocation());
 			return;
 		}
 	}
+
 
 	// 향후 상자, NPC 등 다른 상호작용 대상 추가 가능
 }

--- a/Source/JRPG/Public/Game/HubSubsystem.h
+++ b/Source/JRPG/Public/Game/HubSubsystem.h
@@ -14,16 +14,16 @@ class JRPG_API UHubSubsystem : public UWorldSubsystem
 	
 public:
 	// 허브 등록
-	void RegisterHub(AActor* Hub);
-	void UnregisterHub(AActor* Hub);
+	void RegisterHub(AActor* HubActor);
+	void UnregisterHub(AActor* HubActor);
 	
 	// 플레이어가 현재 범위 안에 있는 허브 추적 (상호작용 대상)
-	void SetFocusedHub(AActor* Hub);
-	void ClearFocusedHub(AActor* Hub);
+	void SetFocusedHub(AActor* HubActor);
+	void ClearFocusedHub(AActor* HubActor);
 	AActor* GetFocusedHub() const;
 	
 	// 마지막 방문 허브
-	void VisitHub(AActor* HubActor);
+	void VisitHub(AActor* HubActor, const FVector& PlayerLoc);
 	bool HasLastVisitedHub() const;
 
 	// 리스폰 위치
@@ -40,4 +40,7 @@ private:
 	
 	UPROPERTY() TWeakObjectPtr<AActor> FocusedHub;
 	UPROPERTY() TWeakObjectPtr<AActor> LastVisitedHub;
+
+	// E키 상호작용 시점의 플레이어 위치 (리스폰 좌표로 사용)
+	FVector LastVisitedLocation = FVector::ZeroVector;
 };


### PR DESCRIPTION
수정 사항
 - HubSubsystem 
 ㄴ LastVisitedLocation을 추가하여 플레이어가 상호작용 시점의 위치값을 저장 
 ㄴ GetRespawnLocation에서 Hub->GetActorLocation()이 아니라 LastVisitedLocation을 리턴 처리 
 ㄴ VisitHub() 함수 인자 추가 : const FVector& PlayerLocation
 
 - JRPGPlayerController 
 ㄴ 상호작용 시 허브 액터 위치가 아닌 플레이어 위치를 넘기게 수정